### PR TITLE
Empty minimanta.json in resource fork crashes server

### DIFF
--- a/lib/fstor.js
+++ b/lib/fstor.js
@@ -399,7 +399,19 @@ FstorObject.prototype._readMeta = function readMeta(cb) {
 			data += chunk;
 	});
 	rs.on('end', function () {
-		data = JSON.parse(data);
+		if (data === '') {
+			writeDefaultMeta();
+			return;
+		}
+
+		try {
+			data = JSON.parse(data);
+		} catch (e) {
+			cb(new mod_verror.VError(e,
+			    'Failed to parse JSON payload'));
+			return;
+		}
+
 		if (typeof (data) === 'object' && data !== null) {
 			self.fo_meta = data;
 			cb();


### PR DESCRIPTION
I've been running this for the past week while using `manta-sync` on many files, and since deploying the fix there hasn't been an issue.